### PR TITLE
Transform demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   sensor_msgs
   visualization_msgs
+  tf
+  tf_conversions
 )
 
 find_package(Eigen REQUIRED)

--- a/README.md
+++ b/README.md
@@ -3,5 +3,8 @@
 Simple library for segmentation of tabletop and shelf surfaces.
 
 ## Try out the demo
-To run the demo, run `rosrun surface_perception demo output_frame_id cloud_in:=your_cloud_topic` in your terminal.
-If `output_frame_id` is not provided, the output will be in `base_link`. 
+To run the demo, run `rosrun surface_perception demo BASE_FRAME cloud_in:=your_cloud_topic` in your terminal.
+`BASE_FRAME` is the name of a frame whose Z-axis points "up" away from gravity.
+It not specified, `base_link` will be used as the `BASE_FRAME`.
+
+Add a Marker topic to see the segmentation output.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # surface_perception
 
 Simple library for segmentation of tabletop and shelf surfaces.
+
+## Try out the demo
+To run the demo, run `rosrun surface_perception demo your_cloud_frame_id cloud_in:=your_cloud_topic` in your terminal.
+If `your_cloud_frame_id` is not provided, the output will be in `base_link`. 

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 Simple library for segmentation of tabletop and shelf surfaces.
 
 ## Try out the demo
-To run the demo, run `rosrun surface_perception demo your_cloud_frame_id cloud_in:=your_cloud_topic` in your terminal.
-If `your_cloud_frame_id` is not provided, the output will be in `base_link`. 
+To run the demo, run `rosrun surface_perception demo output_frame_id cloud_in:=your_cloud_topic` in your terminal.
+If `output_frame_id` is not provided, the output will be in `base_link`. 

--- a/include/surface_perception/shape_extraction.h
+++ b/include/surface_perception/shape_extraction.h
@@ -26,7 +26,7 @@ namespace surface_perception {
 ///   shorter side of the box.
 /// \param[out] dimensions The dimensions of the oriented bounding box. x, y,
 ///   and z correspond to the directions of the pose.
-void FitBox(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr& input,
+bool FitBox(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr& input,
             const pcl::PointIndicesPtr& indices,
             const pcl::ModelCoefficients::Ptr& model, geometry_msgs::Pose* pose,
             geometry_msgs::Vector3* dimensions);

--- a/include/surface_perception/shape_extraction.h
+++ b/include/surface_perception/shape_extraction.h
@@ -26,6 +26,9 @@ namespace surface_perception {
 ///   shorter side of the box.
 /// \param[out] dimensions The dimensions of the oriented bounding box. x, y,
 ///   and z correspond to the directions of the pose.
+///
+/// \returns reports true when a bounding box can be constructed for the object,
+///   or false if the construction fails.
 bool FitBox(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr& input,
             const pcl::PointIndicesPtr& indices,
             const pcl::ModelCoefficients::Ptr& model, geometry_msgs::Pose* pose,

--- a/package.xml
+++ b/package.xml
@@ -17,12 +17,16 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>tf_conversions</build_depend>
   <build_depend>visualization_msgs</build_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>pcl_conversions</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>tf_conversions</run_depend>
   <run_depend>visualization_msgs</run_depend>
 
   <export>

--- a/src/demo_main.cpp
+++ b/src/demo_main.cpp
@@ -45,6 +45,8 @@ void Demo::Callback(const sensor_msgs::PointCloud2ConstPtr& cloud) {
     tf::transformTFToEigen(transform, affine);
     pcl::transformPointCloud(*pcl_cloud_raw, *pcl_cloud, affine);
     pcl_cloud->header.frame_id = "base_link";
+  } else {
+    pcl_cloud = pcl_cloud_raw;
   }
 
   std::vector<int> indices;

--- a/src/demo_main.cpp
+++ b/src/demo_main.cpp
@@ -33,8 +33,8 @@ class Demo {
 Demo::Demo(const SurfaceViz& viz, const std::string& target_frame,
            const ros::Publisher& input_pub)
     : viz_(viz),
-      target_frame_(target_frame),
       input_pub_(input_pub),
+      target_frame_(target_frame),
       tf_listener_() {}
 
 void Demo::Callback(const sensor_msgs::PointCloud2ConstPtr& cloud) {

--- a/src/segmentation.cpp
+++ b/src/segmentation.cpp
@@ -229,13 +229,10 @@ bool FindObjectsOnSurfaces(PointCloudC::Ptr cloud, pcl::PointIndicesPtr indices,
       Object object;
       object.cloud = cloud;
       object.indices.reset(new pcl::PointIndices(object_indices[j]));
-
-      // Only output the object when the object contains more than 4 points
-      if (object.indices->indices.size() >= min_cluster_size) {
-        ROS_INFO("Object has %ld points", object.indices->indices.size());
-        object.pose_stamped.header.frame_id = cloud->header.frame_id;
-        FitBox(cloud, object.indices, surfaces[i].coefficients,
-               &object.pose_stamped.pose, &object.dimensions);
+      object.pose_stamped.header.frame_id = cloud->header.frame_id;
+      
+      if (FitBox(cloud, object.indices, surfaces[i].coefficients,
+               &object.pose_stamped.pose, &object.dimensions)) {
         surface_objects.objects.push_back(object);
       }
     }

--- a/src/segmentation.cpp
+++ b/src/segmentation.cpp
@@ -115,17 +115,19 @@ bool FindSurfaces(PointCloudC::Ptr cloud, pcl::PointIndices::Ptr indices,
     surface.coefficients.reset(new pcl::ModelCoefficients);
     surface.coefficients->values = coeffs_vec[i].values;
     surface.pose_stamped.header.frame_id = cloud->header.frame_id;
-    FitBox(cloud, indices_vec[i], surface.coefficients,
-           &surface.pose_stamped.pose, &surface.dimensions);
-
-    // Adjust the center of surface
-    double offset =
-        surface.coefficients->values[0] * surface.pose_stamped.pose.position.x +
-        surface.coefficients->values[1] * surface.pose_stamped.pose.position.y +
-        surface.coefficients->values[2] * surface.pose_stamped.pose.position.z +
-        surface.coefficients->values[3];
-    surface.pose_stamped.pose.position.z -= offset;
-    surfaces->push_back(surface);
+    if (FitBox(cloud, indices_vec[i], surface.coefficients,
+               &surface.pose_stamped.pose, &surface.dimensions)) {
+      // Adjust the center of surface
+      double offset = surface.coefficients->values[0] *
+                          surface.pose_stamped.pose.position.x +
+                      surface.coefficients->values[1] *
+                          surface.pose_stamped.pose.position.y +
+                      surface.coefficients->values[2] *
+                          surface.pose_stamped.pose.position.z +
+                      surface.coefficients->values[3];
+      surface.pose_stamped.pose.position.z -= offset;
+      surfaces->push_back(surface);
+    }
   }
 
   return true;
@@ -230,9 +232,9 @@ bool FindObjectsOnSurfaces(PointCloudC::Ptr cloud, pcl::PointIndicesPtr indices,
       object.cloud = cloud;
       object.indices.reset(new pcl::PointIndices(object_indices[j]));
       object.pose_stamped.header.frame_id = cloud->header.frame_id;
-      
+
       if (FitBox(cloud, object.indices, surfaces[i].coefficients,
-               &object.pose_stamped.pose, &object.dimensions)) {
+                 &object.pose_stamped.pose, &object.dimensions)) {
         surface_objects.objects.push_back(object);
       }
     }

--- a/src/segmentation.cpp
+++ b/src/segmentation.cpp
@@ -229,10 +229,15 @@ bool FindObjectsOnSurfaces(PointCloudC::Ptr cloud, pcl::PointIndicesPtr indices,
       Object object;
       object.cloud = cloud;
       object.indices.reset(new pcl::PointIndices(object_indices[j]));
-      object.pose_stamped.header.frame_id = cloud->header.frame_id;
-      FitBox(cloud, object.indices, surfaces[i].coefficients,
-             &object.pose_stamped.pose, &object.dimensions);
-      surface_objects.objects.push_back(object);
+
+      // Only output the object when the object contains more than 4 points
+      if (object.indices->indices.size() >= min_cluster_size) {
+        ROS_INFO("Object has %ld points", object.indices->indices.size());
+        object.pose_stamped.header.frame_id = cloud->header.frame_id;
+        FitBox(cloud, object.indices, surfaces[i].coefficients,
+               &object.pose_stamped.pose, &object.dimensions);
+        surface_objects.objects.push_back(object);
+      }
     }
     surfaces_objects_vec->push_back(surface_objects);
   }

--- a/src/shape_extraction.cpp
+++ b/src/shape_extraction.cpp
@@ -12,91 +12,97 @@
 #include "pcl/surface/convex_hull.h"
 #include "ros/ros.h"
 
-#include "surface_perception/typedefs.h"
 #include "pcl/features/normal_3d.h"
+#include "surface_perception/typedefs.h"
 
 namespace {
-bool checkConvexHull(const pcl::ModelCoefficients::Ptr& model, const PointCloudC::Ptr& flat_projected) {
-    Eigen::Vector3d x_axis_ (1.0, 0.0, 0.0);
-    Eigen::Vector3d y_axis_ (0.0, 1.0, 0.0);
-    Eigen::Vector3d z_axis_ (0.0, 0.0, 1.0);
+/**
+ * This helper function checks if the input object can be projected onto the xy
+ * plane in the ConvexHull algorithm.
+ */
+bool hasHullOnXYPlane(const pcl::ModelCoefficients::Ptr& model,
+                      const PointCloudC::Ptr& flat_projected) {
+  Eigen::Vector3d x_axis_(1.0, 0.0, 0.0);
+  Eigen::Vector3d y_axis_(0.0, 1.0, 0.0);
+  Eigen::Vector3d z_axis_(0.0, 0.0, 1.0);
 
-    std::vector<int> *indices_ = new std::vector<int>();
-    for (size_t i = 0; i < flat_projected->points.size(); i++) {
-      indices_->push_back(i);
-    }
-    double projection_angle_thresh_ = cos (0.174532925);
-    int dimension = 2;
-    bool xy_proj_safe = true;
-    bool yz_proj_safe = true;
-    bool xz_proj_safe = true;
+  std::vector<int>* indices_ = new std::vector<int>();
+  for (size_t i = 0; i < flat_projected->points.size(); i++) {
+    indices_->push_back(i);
+  }
+  double projection_angle_thresh_ = cos(0.174532925);
+  int dimension = 2;
+  bool xy_proj_safe = true;
+  bool yz_proj_safe = true;
+  bool xz_proj_safe = true;
 
-    // Check the input's normal to see which projection to use
-    PointC p0 = flat_projected->points[(*indices_)[0]];
-    PointC p1 = flat_projected->points[(*indices_)[indices_->size () - 1]];
-    PointC p2 = flat_projected->points[(*indices_)[indices_->size () / 2]];
+  // Check the input's normal to see which projection to use
+  PointC p0 = flat_projected->points[(*indices_)[0]];
+  PointC p1 = flat_projected->points[(*indices_)[indices_->size() - 1]];
+  PointC p2 = flat_projected->points[(*indices_)[indices_->size() / 2]];
 
-    Eigen::Array4f dy1dy2 = (p1.getArray4fMap () - p0.getArray4fMap ()) / (p2.getArray4fMap () - p0.getArray4fMap ());
-    while (!( (dy1dy2[0] != dy1dy2[1]) || (dy1dy2[2] != dy1dy2[1]) ) )
-    {
-      p0 = flat_projected->points[(*indices_)[rand () % indices_->size ()]];
-      p1 = flat_projected->points[(*indices_)[rand () % indices_->size ()]];
-      p2 = flat_projected->points[(*indices_)[rand () % indices_->size ()]];
-      dy1dy2 = (p1.getArray4fMap () - p0.getArray4fMap ()) / (p2.getArray4fMap () - p0.getArray4fMap ());
-    }
-     
-    pcl::PointCloud<PointC> normal_calc_cloud;
-    normal_calc_cloud.points.resize (3);
-    normal_calc_cloud.points[0] = p0;
-    normal_calc_cloud.points[1] = p1;
-    normal_calc_cloud.points[2] = p2;
-      
-    Eigen::Vector4d normal_calc_centroid;
-    Eigen::Matrix3d normal_calc_covariance;
-    pcl::computeMeanAndCovarianceMatrix (normal_calc_cloud, normal_calc_covariance, normal_calc_centroid);
-    // Need to set -1 here. See eigen33 for explanations.
-    Eigen::Vector3d::Scalar eigen_value;
-    Eigen::Vector3d plane_params;
-    pcl::eigen33 (normal_calc_covariance, eigen_value, plane_params);
-    float theta_x = fabsf (static_cast<float> (plane_params.dot (x_axis_)));
-    float theta_y = fabsf (static_cast<float> (plane_params.dot (y_axis_)));
-    float theta_z = fabsf (static_cast<float> (plane_params.dot (z_axis_)));
+  Eigen::Array4f dy1dy2 = (p1.getArray4fMap() - p0.getArray4fMap()) /
+                          (p2.getArray4fMap() - p0.getArray4fMap());
+  while (!((dy1dy2[0] != dy1dy2[1]) || (dy1dy2[2] != dy1dy2[1]))) {
+    p0 = flat_projected->points[(*indices_)[rand() % indices_->size()]];
+    p1 = flat_projected->points[(*indices_)[rand() % indices_->size()]];
+    p2 = flat_projected->points[(*indices_)[rand() % indices_->size()]];
+    dy1dy2 = (p1.getArray4fMap() - p0.getArray4fMap()) /
+             (p2.getArray4fMap() - p0.getArray4fMap());
+  }
 
-    std::vector<PointC> points;
-    points.push_back(p0);
-    points.push_back(p1);
-    points.push_back(p2);
- 
-    // Check for degenerate cases of each projection
-    // We must avoid projections in which the plane projects as a line
-    if (theta_z > projection_angle_thresh_)
-    {
-      xz_proj_safe = false;
-      yz_proj_safe = false;
-    }
-    if (theta_x > projection_angle_thresh_)
-    {
-      xz_proj_safe = false;
-      xy_proj_safe = false;
-    }
-    if (theta_y > projection_angle_thresh_)
-    {
-      xy_proj_safe = false;
-      yz_proj_safe = false;
-    }
+  pcl::PointCloud<PointC> normal_calc_cloud;
+  normal_calc_cloud.points.resize(3);
+  normal_calc_cloud.points[0] = p0;
+  normal_calc_cloud.points[1] = p1;
+  normal_calc_cloud.points[2] = p2;
 
-    if (!xy_proj_safe) {
-      ROS_INFO("Worning: could not use the following three points to calculate convex hull!");
-      ROS_INFO("P0 (%f, %f, %f)", p0.x, p0.y, p0.z);
-      ROS_INFO("P1 (%f, %f, %f)", p1.x, p1.y, p1.z);
-      ROS_INFO("P2 (%f, %f, %f)", p2.x, p2.y, p2.z);
+  Eigen::Vector4d normal_calc_centroid;
+  Eigen::Matrix3d normal_calc_covariance;
+  pcl::computeMeanAndCovarianceMatrix(normal_calc_cloud, normal_calc_covariance,
+                                      normal_calc_centroid);
+  // Need to set -1 here. See eigen33 for explanations.
+  Eigen::Vector3d::Scalar eigen_value;
+  Eigen::Vector3d plane_params;
+  pcl::eigen33(normal_calc_covariance, eigen_value, plane_params);
+  float theta_x = fabsf(static_cast<float>(plane_params.dot(x_axis_)));
+  float theta_y = fabsf(static_cast<float>(plane_params.dot(y_axis_)));
+  float theta_z = fabsf(static_cast<float>(plane_params.dot(z_axis_)));
 
-      return false;
-    }
+  std::vector<PointC> points;
+  points.push_back(p0);
+  points.push_back(p1);
+  points.push_back(p2);
 
-    return true;
+  // Check for degenerate cases of each projection
+  // We must avoid projections in which the plane projects as a line
+  if (theta_z > projection_angle_thresh_) {
+    xz_proj_safe = false;
+    yz_proj_safe = false;
+  }
+  if (theta_x > projection_angle_thresh_) {
+    xz_proj_safe = false;
+    xy_proj_safe = false;
+  }
+  if (theta_y > projection_angle_thresh_) {
+    xy_proj_safe = false;
+    yz_proj_safe = false;
+  }
+
+  if (!xy_proj_safe) {
+    ROS_WARN(
+        "Warning: could not use the following three points to calculate convex "
+        "hull!");
+    ROS_WARN("P0 (%f, %f, %f)", p0.x, p0.y, p0.z);
+    ROS_WARN("P1 (%f, %f, %f)", p1.x, p1.y, p1.z);
+    ROS_WARN("P2 (%f, %f, %f)", p2.x, p2.y, p2.z);
+
+    return false;
+  }
+
+  return true;
 }
-}
+}  // namespace
 
 namespace surface_perception {
 bool FitBox(const PointCloudC::Ptr& input,
@@ -153,7 +159,8 @@ bool FitBox(const PointCloudC::Ptr& input,
   pcl::PointCloud<pcl::PointXYZRGB> hull;
   pcl::ConvexHull<pcl::PointXYZRGB> convex_hull;
 
-  if (checkConvexHull(model, flat_projected)) {
+  // Check if ConvexHull works for the given object
+  if (hasHullOnXYPlane(model, flat_projected)) {
     convex_hull.setInputCloud(flat_projected);
     convex_hull.setDimension(2);
     convex_hull.reconstruct(hull);


### PR DESCRIPTION
See the [contribution checklist](https://github.com/jstnhuang/rapid_pbd/blob/indigo-devel/.github/CONTRIBUTING.md).

One-line description of pull request:
Fix the bug for the algorithm crash on some input point cloud, and add additional parameter for the demo.

Detailed description of pull request:
Previously, surface_perception may crash when the input cloud causes error in ConvexHull during the bounding box construction, because ConvexHull attempts to find the hull on the wrong plane. Now surface_perception checks if ConvexHull can find the hull on xy-plane for the given object, before actually running ConvexHull algorithm. Apart from this, demo supports an additional parameter to allow frame transformation from one frame to another.

How was this PR tested?
It was tested by the following two videos:
https://drive.google.com/open?id=18woISemTAqf02SqWaShvEWSQh1l9LjCe
https://drive.google.com/open?id=19Dar_tChpv0H7GkNBbNrizHjeHeh4MiD
Please note that an bounding box construction check is added for the surface bounding box construction, after recording these videos.