### PR TITLE
Parameter decoupling

### DIFF
--- a/include/surface_perception/axes_marker.h
+++ b/include/surface_perception/axes_marker.h
@@ -6,7 +6,7 @@
 
 namespace surface_perception {
 /// \brief This helper function generates a marker array where axes are
-///  represented by three markers of colored cylinder bars.
+///   represented by three markers of colored cylinder bars.
 ///
 /// \b Example usage:
 /// \code
@@ -23,10 +23,10 @@ namespace surface_perception {
 /// \param[in] frame_id The id of the frame where the markers will be.
 /// \param[in] pose The pose of the origin where the three axes intersect.
 /// \param[in] scale The length of each colored cylinder bars. The cylinder
-///  diameters are 10% of scale, or 1 cm if 10% scale is less than 1 cm.
+///   diameters are 10% of scale, or 1 cm if 10% scale is less than 1 cm.
 ///
 /// \return A MarkerArray of three Marker objects is returned where x-axis is
-///  a red cylinder, y-axis is a green cylinder and z-axis is a blue cylinder.
+///   a red cylinder, y-axis is a green cylinder and z-axis is a blue cylinder.
 visualization_msgs::MarkerArray GetAxesMarkerArray(
     const std::string& name_space, const std::string& frame_id,
     geometry_msgs::Pose pose, double scale);

--- a/include/surface_perception/segmentation.h
+++ b/include/surface_perception/segmentation.h
@@ -133,7 +133,7 @@ class Segmentation {
   /// to determine the quality of the explored surfaces for the output.
   ///
   /// \param[in] max_point_distance The maximum distance threshold of surface
-  ///  inlier points. 
+  ///   inlier points.
   void set_max_point_distance(double max_point_distance);
 
   /// \brief Segments the scene.

--- a/include/surface_perception/segmentation.h
+++ b/include/surface_perception/segmentation.h
@@ -124,6 +124,18 @@ class Segmentation {
   void set_min_surface_exploration_iteration(
       int min_surface_exploration_iteration);
 
+  /// \brief Sets the maximum distance of inlier points considered to be part of
+  ///  a surface.
+  ///
+  /// As the surface exploration algorithm explores surfaces in the given point
+  /// cloud scene, the value of max_point_distance is used to compute the number
+  /// of inlier points for a surface. The number of surface inliers is then used
+  /// to determine the quality of the explored surfaces for the output.
+  ///
+  /// \param[in] max_point_distance The maximum distance threshold of surface
+  ///  inlier points. 
+  void set_max_point_distance(double max_point_distance);
+
   /// \brief Segments the scene.
   ///
   /// \param[out] surfaces The vector of SurfaceObjects to append to. This
@@ -142,6 +154,7 @@ class Segmentation {
   double horizontal_tolerance_degrees_;
   double margin_above_surface_;
   double cluster_distance_;
+  double max_point_distance_;
   int min_cluster_size_;
   int max_cluster_size_;
   int min_surface_size_;
@@ -153,7 +166,7 @@ class Segmentation {
 /// \param[in] cloud The point cloud to find a surface in, where positive z
 ///   points up.
 /// \param[in] indices The indices in the point cloud to find a surface in.
-/// \param[in] margin_above_surface The maximum distance between a plane and a
+/// \param[in] max_point_distance The maximum distance between a plane and a
 ///   point, in order to be considered as part of a surface.
 /// \param[in] horizontal_tolerance_degrees The tolerance, in degrees, for a
 ///   surface to be considered horizontal.
@@ -165,7 +178,7 @@ class Segmentation {
 ///
 /// \returns true if a surface was found, false otherwise.
 bool FindSurfaces(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud,
-                  pcl::PointIndicesPtr indices, double margin_above_surface,
+                  pcl::PointIndicesPtr indices, double max_point_distance,
                   double horizontal_tolerance_degrees, int min_surface_size,
                   int min_surface_exploration_iteration,
                   std::vector<Surface>* surfaces);

--- a/src/demo_main.cpp
+++ b/src/demo_main.cpp
@@ -90,7 +90,9 @@ void Demo::Callback(const sensor_msgs::PointCloud2ConstPtr& cloud) {
   ros::param::param("horizontal_tolerance_degrees",
                     horizontal_tolerance_degrees, 10.0);
   double margin_above_surface;
-  ros::param::param("margin_above_surface", margin_above_surface, 0.015);
+  ros::param::param("margin_above_surface", margin_above_surface, 0.025);
+  double max_point_distance;
+  ros::param::param("max_point_distance", max_point_distance, 0.015);
   double cluster_distance;
   ros::param::param("cluster_distance", cluster_distance, 0.01);
   int min_cluster_size;
@@ -108,6 +110,7 @@ void Demo::Callback(const sensor_msgs::PointCloud2ConstPtr& cloud) {
   seg.set_indices(point_indices);
   seg.set_horizontal_tolerance_degrees(horizontal_tolerance_degrees);
   seg.set_margin_above_surface(margin_above_surface);
+  seg.set_max_point_distance(max_point_distance);
   seg.set_cluster_distance(cluster_distance);
   seg.set_min_cluster_size(min_cluster_size);
   seg.set_max_cluster_size(max_cluster_size);

--- a/src/segmentation.cpp
+++ b/src/segmentation.cpp
@@ -32,6 +32,7 @@ Segmentation::Segmentation()
       horizontal_tolerance_degrees_(10),
       margin_above_surface_(0.005),
       cluster_distance_(0.01),
+      max_point_distance_(0.005),
       min_cluster_size_(10),
       max_cluster_size_(10000),
       min_surface_size_(5000),
@@ -68,9 +69,13 @@ void Segmentation::set_min_surface_exploration_iteration(
     int min_surface_exploration_iteration) {
   min_surface_exploration_iteration_ = min_surface_exploration_iteration;
 }
+void Segmentation::set_max_point_distance(double max_point_distance) {
+  max_point_distance_ = max_point_distance;
+}
+
 bool Segmentation::Segment(std::vector<SurfaceObjects>* surfaces) const {
   std::vector<Surface> surface_vec;
-  bool success = FindSurfaces(cloud_, indices_, margin_above_surface_,
+  bool success = FindSurfaces(cloud_, indices_, max_point_distance_,
                               horizontal_tolerance_degrees_, min_surface_size_,
                               min_surface_exploration_iteration_, &surface_vec);
   if (!success) {
@@ -90,7 +95,7 @@ bool Segmentation::Segment(std::vector<SurfaceObjects>* surfaces) const {
 }
 
 bool FindSurfaces(PointCloudC::Ptr cloud, pcl::PointIndices::Ptr indices,
-                  double margin_above_surface,
+                  double max_point_distance,
                   double horizontal_tolerance_degrees, int min_surface_size,
                   int min_surface_exploration_iteration,
                   std::vector<Surface>* surfaces) {
@@ -102,7 +107,7 @@ bool FindSurfaces(PointCloudC::Ptr cloud, pcl::PointIndices::Ptr indices,
   surfaceFinder.set_min_iteration(min_surface_exploration_iteration);
   surfaceFinder.set_surface_point_threshold(min_surface_size);
   surfaceFinder.set_angle_tolerance_degree(horizontal_tolerance_degrees);
-  surfaceFinder.set_max_point_distance(margin_above_surface);
+  surfaceFinder.set_max_point_distance(max_point_distance);
   surfaceFinder.ExploreSurfaces(&indices_vec, &coeffs_vec);
 
   if (indices_vec.size() == 0 || coeffs_vec.size() == 0) {


### PR DESCRIPTION
See the [contribution checklist](https://github.com/jstnhuang/rapid_pbd/blob/indigo-devel/.github/CONTRIBUTING.md).

One-line description of pull request:
Decouple two parameters in Segmentation class

Detailed description of pull request:
In the old implementation, margin_above_surface in Segmentation class is used as max_point_distance in SurfaceFinder, which resulted in coarse parameter control in object segmentation. This pull request adds an additional setter function in Segmentation class for the parameter, max_point_distance, to be used in SurfaceFinder.

How was this PR tested?
This pull request is tested through demo video: https://drive.google.com/open?id=1XQAhZBbpOlWc5tMXpyHcSVQ2HrQ_lTXA
