### PR TITLE
Fixed incorrect z axis orientation in GetAxesMarkerArray

### DIFF
--- a/src/axes_marker.cpp
+++ b/src/axes_marker.cpp
@@ -95,12 +95,8 @@ visualization_msgs::MarkerArray GetAxesMarkerArray(
   z_axis.scale.x = z_axis.scale.y = std::max(scale * 0.1, 0.01);
   z_axis.scale.z = scale;
 
-  // Z axis orientation, which has the same rotation_matrix from the given pose.
-  Eigen::Quaternionf z_quaternion(rotation_matrix);
-  z_axis.pose.orientation.x = z_quaternion.x();
-  z_axis.pose.orientation.y = z_quaternion.y();
-  z_axis.pose.orientation.z = z_quaternion.z();
-  z_axis.pose.orientation.w = z_quaternion.w();
+  // Z axis orientation, which has the same orientation as the given pose.
+  z_axis.pose.orientation = pose.orientation;
 
   // Z axis position shifting
   z_axis.pose.position = pose.position;

--- a/src/axes_marker.cpp
+++ b/src/axes_marker.cpp
@@ -95,7 +95,14 @@ visualization_msgs::MarkerArray GetAxesMarkerArray(
   z_axis.scale.x = z_axis.scale.y = std::max(scale * 0.1, 0.01);
   z_axis.scale.z = scale;
 
-  // Z axis orientation
+  // Z axis orientation, which has the same rotation_matrix from the given pose.
+  Eigen::Quaternionf z_quaternion(rotation_matrix);
+  z_axis.pose.orientation.x = z_quaternion.x();
+  z_axis.pose.orientation.y = z_quaternion.y();
+  z_axis.pose.orientation.z = z_quaternion.z();
+  z_axis.pose.orientation.w = z_quaternion.w();
+
+  // Z axis position shifting
   z_axis.pose.position = pose.position;
   Eigen::Vector3f z_position =
       Eigen::Vector3f(pose.position.x, pose.position.y, pose.position.z) +


### PR DESCRIPTION
See the [contribution checklist](https://github.com/jstnhuang/rapid_pbd/blob/indigo-devel/.github/CONTRIBUTING.md).

One-line description of pull request:
Fixed the incorrect orientation/position of z-axis in axes markers

Detailed description of pull request:
This pull request solves the issue with z-axis in axes markers, where z axis was always pointing upwards with incorrect position, regardless the given pose. The solution to this issue is to make the generated z axis use the same orientation as the given pose, so that z axis position can be correctly adjusted.

How was this PR tested?
Before fix: https://drive.google.com/open?id=1UKPsdIhirHadN8_NA7p6tzOwCNfmwXbc
After fix: https://drive.google.com/open?id=1HWSQSpcXYfhw3B2LQfPSiiKL7FtMri79